### PR TITLE
add ability to retrieve raw HTTP responses and RawIP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,29 @@ if err != nil {
 
 fmt.Printf("%s (%s)\n", data.IP, data.ASN)
 ```
+
+You can also use the error returned from the methods to determine whether it was
+a failure due to a rate limit. This package uses the
+[github.com/pkg/errors](https://github.com/pkg/errors) package for error
+handling, which allows you to wrap errors to provide more context. Using this
+functionality is entirely optional.
+
+```Go
+import "github.com/pkg/errors"
+
+data, err := ipd.Lookup("8.8.8.8")
+if err != nil {
+	// do a type assertion on the error
+	rerr, ok := errors.Cause(err).(interface{
+    	RateLimited() bool
+    })
+
+    if !ok {
+    	// this wasn't a failure from rate limiting
+    }
+
+    if rerr.RateLimited() {
+    	// we were rate limited
+    }
+}
+```

--- a/client_test.go
+++ b/client_test.go
@@ -6,12 +6,15 @@ package ipdata
 
 import (
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 func testHTTPServer(addr string) (net.Listener, *http.Server, error) {
@@ -228,5 +231,272 @@ func Test_client_Lookup(t *testing.T) {
 				t.Errorf("ip.TimeZone = %q, want %q", a, b)
 			}
 		})
+	}
+}
+
+func Test_client_LookupRaw(t *testing.T) {
+	ln, srvr, err := testHTTPServer("")
+	if err != nil {
+		t.Fatalf(`testHTTPServer("") returned unexpected error: %s`, err)
+	}
+
+	defer ln.Close()
+	defer srvr.Close()
+
+	c := client{
+		c: newHTTPClient(),
+		e: "http://" + ln.Addr().String() + "/",
+	}
+
+	tests := []struct {
+		name string
+		i    string
+		o    RawIP
+		e    string
+	}{
+		{
+			name: "private_ipv4",
+			i:    "192.168.0.1",
+			e:    "192.168.0.1 is a private IP address",
+		},
+		{
+			name: "invalid_ip",
+			i:    "bacon",
+			e:    "bacon does not appear to be an IPv4 or IPv6 address",
+		},
+		{
+			name: "rate_limited",
+			i:    "8.8.8.8",
+			e:    "You have exceeded your free tier limit of 1500 requests. Register for a paid plan at https://ipdata.co to make more requests.",
+		},
+		{
+			name: "valid_address",
+			i:    "76.14.47.42",
+			o: RawIP{
+				IP:             "76.14.47.42",
+				ASN:            "AS11404",
+				Organization:   "vanoppen.biz LLC",
+				City:           "San Francisco",
+				Region:         "California",
+				Postal:         "94132",
+				CountryName:    "United States",
+				CountryCode:    "US",
+				Flag:           "https://ipdata.co/flags/us.png",
+				ContinentName:  "North America",
+				ContinentCode:  "NA",
+				Latitude:       37.723,
+				Longitude:      -122.4842,
+				CallingCode:    "1",
+				Currency:       "USD",
+				CurrencySymbol: "$",
+				TimeZone:       "America/Los_Angeles",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			var ip RawIP
+			var err error
+
+			ip, err = c.LookupRaw(tt.i)
+
+			if len(tt.e) > 0 {
+				if err == nil {
+					t.Fatal("error expected but was nil")
+				}
+
+				if !strings.Contains(err.Error(), tt.e) {
+					t.Fatalf("error message %q not found in error: %s", tt.e, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("LookupRaw(%q) unexpected error: %s", tt.i, err)
+			}
+
+			if ip.IP != tt.o.IP {
+				t.Errorf("ip.IP = %q, want %q", ip.IP, tt.o.IP)
+			}
+
+			if ip.ASN != tt.o.ASN {
+				t.Errorf("ip.ASN = %q, want %q", ip.ASN, tt.o.ASN)
+			}
+
+			if ip.Organization != tt.o.Organization {
+				t.Errorf("ip.Organization = %q, want %q", ip.Organization, tt.o.Organization)
+			}
+
+			if ip.City != tt.o.City {
+				t.Errorf("ip.City = %q, want %q", ip.City, tt.o.City)
+			}
+
+			if ip.Region != tt.o.Region {
+				t.Errorf("ip.Region = %q, want %q", ip.Region, tt.o.Region)
+			}
+
+			if ip.Postal != tt.o.Postal {
+				t.Errorf("ip.Postal = %q, want %q", ip.Postal, tt.o.Postal)
+			}
+
+			if ip.CountryName != tt.o.CountryName {
+				t.Errorf("ip.CountryName = %q, want %q", ip.CountryName, tt.o.CountryName)
+			}
+
+			if ip.CountryCode != tt.o.CountryCode {
+				t.Errorf("ip.CountryCode = %q, want %q", ip.CountryCode, tt.o.CountryCode)
+			}
+
+			if ip.Flag != tt.o.Flag {
+				t.Errorf("ip.Flag = %q, want %q", ip.Flag, tt.o.Flag)
+			}
+
+			if ip.ContinentName != tt.o.ContinentName {
+				t.Errorf("ip.ContinentName = %q, want %q", ip.ContinentName, tt.o.ContinentName)
+			}
+
+			if ip.ContinentCode != tt.o.ContinentCode {
+				t.Errorf("ip.ContinentCode = %q, want %q", ip.ContinentCode, tt.o.ContinentCode)
+			}
+
+			if ip.Latitude != tt.o.Latitude {
+				t.Errorf("ip.Latitude = %f, want %f", ip.Latitude, tt.o.Latitude)
+			}
+
+			if ip.Longitude != tt.o.Longitude {
+				t.Errorf("ip.Longitude = %f, want %f", ip.Longitude, tt.o.Longitude)
+			}
+
+			if ip.CallingCode != tt.o.CallingCode {
+				t.Errorf("ip.CallingCode = %q, want %q", ip.CallingCode, tt.o.CallingCode)
+			}
+
+			if ip.Currency != tt.o.Currency {
+				t.Errorf("ip.Currency = %q, want %q", ip.Currency, tt.o.Currency)
+			}
+
+			if ip.CurrencySymbol != tt.o.CurrencySymbol {
+				t.Errorf("ip.CurrencySymbol = %q, want %q", ip.CurrencySymbol, tt.o.CurrencySymbol)
+			}
+
+			if ip.TimeZone != tt.o.TimeZone {
+				t.Errorf("ip.TimeZone = %q, want %q", ip.TimeZone, tt.o.TimeZone)
+			}
+		})
+	}
+}
+
+func Test_client_Request(t *testing.T) {
+	ln, srvr, err := testHTTPServer("")
+	if err != nil {
+		t.Fatalf(`testHTTPServer("") returned unexpected error: %s`, err)
+	}
+
+	defer ln.Close()
+	defer srvr.Close()
+
+	c := client{
+		c: newHTTPClient(),
+		e: "http://" + ln.Addr().String() + "/",
+	}
+
+	tests := []struct {
+		name string
+		i    string
+		o    string
+		e    string
+	}{
+		{
+			name: "private_ipv4",
+			i:    "192.168.0.1",
+			e:    "192.168.0.1 is a private IP address",
+		},
+		{
+			name: "invalid_ip",
+			i:    "bacon",
+			e:    "bacon does not appear to be an IPv4 or IPv6 address",
+		},
+		{
+			name: "rate_limited",
+			i:    "8.8.8.8",
+			e:    "You have exceeded your free tier limit of 1500 requests. Register for a paid plan at https://ipdata.co to make more requests.",
+		},
+		{
+			name: "valid_address",
+			i:    "76.14.47.42",
+			o:    testJSONValid,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			var resp *http.Response
+			var err error
+
+			resp, err = c.Request(tt.i)
+
+			if len(tt.e) > 0 {
+				if err == nil {
+					t.Fatal("error expected but was nil")
+				}
+
+				if !strings.Contains(err.Error(), tt.e) {
+					t.Fatalf("error message %q not found in error: %s", tt.e, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Request(%q) unexpected error: %s", tt.i, err)
+			}
+
+			defer resp.Body.Close()
+
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("unexpected error reading response body: %s", err)
+			}
+
+			if str := string(body); str != tt.o {
+				t.Fatalf("resp.Body = %q, want %q", str, tt.o)
+			}
+		})
+	}
+}
+
+func Test_client_Lookup_error(t *testing.T) {
+	ln, srvr, err := testHTTPServer("")
+	if err != nil {
+		t.Fatalf(`testHTTPServer("") returned unexpected error: %s`, err)
+	}
+
+	defer ln.Close()
+	defer srvr.Close()
+
+	c := client{
+		c: newHTTPClient(),
+		e: "http://" + ln.Addr().String() + "/",
+	}
+
+	_, err = c.Request("8.8.8.8")
+	if err != nil {
+		rerr, ok := errors.Cause(err).(interface {
+			RateLimited() bool
+		})
+
+		if !ok {
+			t.Fatal("error does not implement RateLimited interface")
+		}
+
+		if !rerr.RateLimited() {
+			t.Fatal("error returned did not indicate it was RateLimited")
+		}
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package ipdata
+
+type rateErr struct {
+	m string
+	r bool
+}
+
+func (e rateErr) Error() string {
+	return e.m
+}
+
+func (e rateErr) RateLimited() bool {
+	return e.r
+}


### PR DESCRIPTION
This change adds the ability for library consumers to use lower-level portions
of the API client from the outside. This includes two new methods to the Client
interface, and an error type that allows you determine whether your request
failed due to rate limits.

Signed-off-by: Tim Heckman <t@heckman.io>