### PR TITLE
Fix bugs uncovered with the increase in test coverage

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -52,7 +52,7 @@ func testHTTPServer(addr string) (net.Listener, *http.Server, error) {
 	})
 
 	mux.HandleFunc("/8.4.0.3", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized) // TODO(theckman) use StatusForbidden soon
+		w.WriteHeader(http.StatusForbidden)
 		io.WriteString(w, "unexpected HTTP status code")
 	})
 
@@ -495,25 +495,25 @@ func Test_client_Request(t *testing.T) {
 			c:    c,
 			name: "unexpected_error",
 			i:    "8.4.0.3",
-			e:    "unexpected http status: 401 Unauthorized",
+			e:    "unexpected http status: 403 Forbidden",
 		},
-		// TODO(theckman): enable these tests
-		// {
-		// 	c:    client{c: newHTTPClient(), e: "http://127.0.0.1:8404/", k: "testAPIkey"},
-		// 	name: "tcp_conn_err",
-		// 	i:    "76.14.47.42",
-		// 	e:    `http request to "http://127.0.0.1:8404/76.14.47.42" failed`,
-		// },
-		// {
-		// 	name: "invalid_api-key",
-		// 	i:    "8.8.4.4",
-		// 	e:    "(authentication failure)",
-		// },
+		{
+			c:    c,
+			name: "invalid_api-key",
+			i:    "8.8.4.4",
+			e:    "(authentication failure)",
+		},
 		{
 			c:    c,
 			name: "valid_address",
 			i:    "76.14.47.42",
 			o:    testJSONValid,
+		},
+		{
+			c:    client{c: newHTTPClient(), e: "http://127.0.0.1:8404/", k: "testAPIkey"},
+			name: "tcp_conn_err",
+			i:    "76.14.47.42",
+			e:    `http request to "http://127.0.0.1:8404/76.14.47.42" failed`,
 		},
 	}
 


### PR DESCRIPTION
* Potential `nil` pointer dereference when the outbound HTTP request experienced
  an error (request failed to complete).
* Mistakenly expecting 403 to be the status code used when the API key provided
  is invalid.

The first issue was that the `*http.Response` returned from `*http.Client.Do()`
was being used in the error handling block for that function call to get the
request's URL. This was updated to properly use `req.URL`.

The second issue was simply catching the wrong HTTP status code on request
processing. This updates the code, and tests, to use http.StatusUnauthorized for
authentication failures.

Signed-off-by: Tim Heckman <t@heckman.io>