### PR TITLE
Remove the "test_" prefix from the subtests that had it

### DIFF
--- a/ipdata_test.go
+++ b/ipdata_test.go
@@ -142,7 +142,7 @@ func Test_ripToIP(t *testing.T) {
 			e:    "failed to parse timezone",
 		},
 		{
-			name: "test_valid_RawIP",
+			name: "valid_RawIP",
 			i: RawIP{
 				IP:             "76.14.47.42",
 				ASN:            "AS11404",
@@ -286,12 +286,12 @@ func TestDecodeRawIP(t *testing.T) {
 		e    string
 	}{
 		{
-			name: "test_invalid_json",
+			name: "invalid_json",
 			i:    "garbage",
 			e:    "failed to parse JSON:",
 		},
 		{
-			name: "test_valid_json",
+			name: "valid_json",
 			i:    testJSONValid,
 			o: RawIP{
 				IP:             "76.14.47.42",
@@ -436,7 +436,7 @@ func TestDecodeIP(t *testing.T) {
 			e:    "failed to parse flag",
 		},
 		{
-			name: "test_valid_json",
+			name: "valid_json",
 			i:    testJSONValid,
 			o: IP{
 				IP:             net.ParseIP("76.14.47.42"),


### PR DESCRIPTION
The prefix of "test_" on a subtest name obviously provided no value, so this
goes ahead and removes all usage of it.

This is completely cosmetic and has no impact on the library or its tests.

Signed-off-by: Tim Heckman <t@heckman.io>