### PR TITLE
Rename Request() to RawLookup() to prepare for BulkLookup()

### DIFF
--- a/client.go
+++ b/client.go
@@ -62,11 +62,11 @@ type apiErr struct {
 	Message string `json:"message"`
 }
 
-// Request uses the internal mechanics to make an HTTP request to the API and
+// RawLookup uses the internal mechanics to make an HTTP request to the API and
 // returns the HTTP response. This allows consumers of the API to implement
 // their own behaviors. If an API error occurs, the error value will be of type
 // Error.
-func (c Client) Request(ip string) (*http.Response, error) {
+func (c Client) RawLookup(ip string) (*http.Response, error) {
 	// build request
 	req, err := newRequest(c.e+ip, c.k)
 	if err != nil {
@@ -119,7 +119,7 @@ func decodeIP(r io.Reader) (IP, error) {
 // you want the information about the current node's pubilc IP address. If an
 // API error occurs, the error value will be of type Error.
 func (c Client) Lookup(ip string) (IP, error) {
-	resp, err := c.Request(ip)
+	resp, err := c.RawLookup(ip)
 	if err != nil {
 		return IP{}, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -368,7 +368,7 @@ func Test_client_Lookup(t *testing.T) {
 	}
 }
 
-func Test_client_Request(t *testing.T) {
+func Test_client_RawLookup(t *testing.T) {
 	ln, srvr, err := testHTTPServer("")
 	if err != nil {
 		t.Fatalf(`testHTTPServer("") returned unexpected error: %s`, err)
@@ -449,7 +449,7 @@ func Test_client_Request(t *testing.T) {
 			var resp *http.Response
 			var err error
 
-			resp, err = tt.c.Request(tt.i)
+			resp, err = tt.c.RawLookup(tt.i)
 
 			if len(tt.e) > 0 {
 				if err == nil {
@@ -464,7 +464,7 @@ func Test_client_Request(t *testing.T) {
 			}
 
 			if err != nil {
-				t.Fatalf("Request(%q) unexpected error: %s", tt.i, err)
+				t.Fatalf("RawLookup(%q) unexpected error: %s", tt.i, err)
 			}
 
 			defer func() {


### PR DESCRIPTION
The `Request()` method name makes less sense when you consider that
`BulkLookup()` will be coming soon, since it can't support a bulk lookup
request.